### PR TITLE
Variables now use GenericEvent class for OnValueChanged

### DIFF
--- a/Runtime/Events/Event.cs
+++ b/Runtime/Events/Event.cs
@@ -46,26 +46,27 @@ namespace SODD.Events
         [Tooltip("Enable this setting to log the invocations of this event in the console.")]
         public bool debug;
 #endif
+
+        protected readonly GenericEvent<T> GenericEvent = new();
         
         /// <inheritdoc />
         public void AddListener(Action<T> listener)
         {
-            Listeners += listener;
+            GenericEvent.AddListener(listener);
         }
 
         /// <inheritdoc />
         public void RemoveListener(Action<T> listener)
         {
-            Listeners -= listener;
+            GenericEvent.RemoveListener(listener);
         }
 
         /// <inheritdoc />
         public void Invoke(T payload)
         {
-            Listeners?.Invoke(payload);
+            GenericEvent.Invoke(payload);
 #if UNITY_EDITOR
             if (!debug) return;
-
             var assetPath = AssetDatabase.GetAssetPath(this);
             var filename = Path.GetFileName(assetPath).Replace(".asset", "");
             var linkToEvent = $"<a href=\"{assetPath}\">{filename}</a>";
@@ -73,7 +74,5 @@ namespace SODD.Events
             Debug.Log(message);
 #endif
         }
-
-        private event Action<T> Listeners;
     }
 }

--- a/Runtime/Events/GenericEvent.cs
+++ b/Runtime/Events/GenericEvent.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace SODD.Events
+{
+    /// <summary>
+    ///     Represents a generic event that can be listened to and invoked.
+    /// </summary>
+    /// <typeparam name="T">The type of the event payload.</typeparam>
+    public sealed class GenericEvent<T> : IEvent<T>
+    {
+        /// <summary>
+        ///     Adds a listener to the event.
+        /// </summary>
+        /// <typeparam name="T">The type of the payload.</typeparam>
+        /// <param name="listener">The listener to add.</param>
+        /// <remarks>
+        ///     This method adds a listener to the event. The listener will be triggered whenever the event is invoked.
+        /// </remarks>
+        public void AddListener(Action<T> listener)
+        {
+            Listeners += listener;
+        }
+
+        /// <summary>
+        ///     Removes the specified listener from the event.
+        /// </summary>
+        /// <typeparam name="T">The type of the listener's argument.</typeparam>
+        /// <param name="listener">The listener to be removed.</param>
+        public void RemoveListener(Action<T> listener)
+        {
+            Listeners -= listener;
+        }
+
+        /// <summary>
+        ///     Invokes the event and notifies all registered listeners with the specified payload.
+        /// </summary>
+        /// <typeparam name="T">The type of the payload.</typeparam>
+        /// <param name="payload">The payload to pass to the listeners.</param>
+        public void Invoke(T payload)
+        {
+            Listeners?.Invoke(payload);
+        }
+
+        /// <summary>
+        ///     Represents a generic event that can be listened to and invoked.
+        /// </summary>
+        /// <typeparam name="T">The type of the event payload.</typeparam>
+        private event Action<T> Listeners;
+    }
+}

--- a/Runtime/Events/GenericEvent.cs.meta
+++ b/Runtime/Events/GenericEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5f66b9e35b604b78bf872625df16d9cc
+timeCreated: 1709194320

--- a/Tests/Editor/Events.meta
+++ b/Tests/Editor/Events.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: aa266a99d60248b7a3e076ff5f0624aa
+timeCreated: 1709195135

--- a/Tests/Editor/Events/GenericEventTests.cs
+++ b/Tests/Editor/Events/GenericEventTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using NUnit.Framework;
+using SODD.Events;
+
+namespace SODD.Tests.Editor.Events
+{
+    [TestFixture]
+    public class GenericEventTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            _event = new GenericEvent<int>();
+        }
+
+        private GenericEvent<int> _event;
+
+        [Test]
+        public void AddListener_ShouldAddListener()
+        {
+            var called = 0;
+            Action<int> listener = payload => { called++; };
+
+            _event.AddListener(listener);
+            _event.Invoke(10);
+
+            Assert.AreEqual(1, called);
+        }
+
+        [Test]
+        public void RemoveListener_ShouldRemoveListener()
+        {
+            var called = 0;
+            Action<int> listener = payload => { called++; };
+
+            _event.AddListener(listener);
+            _event.Invoke(10);
+
+            _event.RemoveListener(listener);
+            _event.Invoke(10);
+
+            Assert.AreEqual(1, called);
+        }
+
+        [Test]
+        public void Invoke_ShouldTriggerAllListeners()
+        {
+            int called1 = 0, called2 = 0;
+            Action<int> listener1 = payload => { called1 += payload; };
+            Action<int> listener2 = payload => { called2 += payload; };
+
+            _event.AddListener(listener1);
+            _event.AddListener(listener2);
+            _event.Invoke(10);
+
+            Assert.AreEqual(10, called1);
+            Assert.AreEqual(10, called2);
+        }
+    }
+}

--- a/Tests/Editor/Events/GenericEventTests.cs.meta
+++ b/Tests/Editor/Events/GenericEventTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fd4f5a258145441fabdff6089a81bc93
+timeCreated: 1709195145

--- a/Tests/Editor/com.github.aruizrab.sodd-unity-framework.Editor.Tests.asmdef
+++ b/Tests/Editor/com.github.aruizrab.sodd-unity-framework.Editor.Tests.asmdef
@@ -1,6 +1,6 @@
 {
   "name": "com.github.aruizrab.sodd-unity-framework.Editor.Tests",
-  "rootNamespace": "SODD.Editor.Tests",
+  "rootNamespace": "SODD",
   "references": [
     "com.github.aruizrab.sodd-unity-framework",
     "com.github.aruizrab.sodd-unity-framework.Editor"


### PR DESCRIPTION
Variables have been refactored to use the more generalized GenericEvent instead of the custom ValueChangedEvent. Correspondingly, the Variables' method `OnSerializedValueChanged` has been replaced with `HandleValueChange`. This change reduces code redundancy and improves maintainability. Unit tests have also been added to ensure correct functionality of the GenericEvent class.